### PR TITLE
ADD CDLA-Permissive-2.0 to the deny.toml allowances

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -21,6 +21,7 @@ allow = [
   "Zlib",
   "Unicode-DFS-2016",
   "Unicode-3.0",
+  "CDLA-Permissive-2.0"
 ]
 # Some crates don't have their license in the Cargo.toml but in the repository
 # We can specify exceptions here


### PR DESCRIPTION
ADD CDLA-Permissive-2.0 to the deny.toml allowances

as it is needed for the rust-tls feature of reqwest, so not to need to have OpenSSL installed